### PR TITLE
Address WinOTP feedback: variable-length TOTP and keyboard copy

### DIFF
--- a/.github/workflows/uwp-ci.yml
+++ b/.github/workflows/uwp-ci.yml
@@ -1,0 +1,126 @@
+name: UWP CI
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+      - 'codex/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: uwp-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: Build and test (${{ matrix.platform }})
+    runs-on: windows-2022
+    timeout-minutes: 45
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - x86
+          - x64
+
+    env:
+      SOLUTION_PATH: Authenticator for Windows.sln
+      BUILD_CONFIGURATION: Debug
+      # The repository targets 10.0.18362.0, but the hosted windows-2022 image
+      # currently has newer Windows SDKs installed. Override the CI build to an
+      # installed SDK while keeping the app's minimum target unchanged.
+      CI_TARGET_PLATFORM_VERSION: 10.0.19041.0
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v3
+
+      - name: Show Visual Studio and SDK inventory
+        shell: pwsh
+        run: |
+          & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.Component.MSBuild -format table
+          Get-ChildItem 'C:\Program Files (x86)\Windows Kits\10\Platforms\UAP' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Name
+
+      - name: Restore NuGet packages
+        shell: pwsh
+        run: |
+          msbuild "${env:SOLUTION_PATH}" `
+            /t:Restore `
+            /p:Platform=${{ matrix.platform }} `
+            /p:Configuration=${env:BUILD_CONFIGURATION} `
+            /p:TargetPlatformVersion=${env:CI_TARGET_PLATFORM_VERSION}
+
+      - name: Build app and test project
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path artifacts | Out-Null
+
+          msbuild "${env:SOLUTION_PATH}" `
+            /m `
+            /restore `
+            /p:Platform=${{ matrix.platform }} `
+            /p:Configuration=${env:BUILD_CONFIGURATION} `
+            /p:TargetPlatformVersion=${env:CI_TARGET_PLATFORM_VERSION} `
+            /p:AppxPackageSigningEnabled=false `
+            /p:GenerateAppxPackageOnBuild=false `
+            /p:AppxBundle=Never `
+            /p:DeployOnBuild=false `
+            /bl:artifacts\msbuild-${{ matrix.platform }}.binlog
+
+      - name: Run UWP unit tests
+        shell: pwsh
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsInstall = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationPath
+          if ([string]::IsNullOrWhiteSpace($vsInstall)) {
+            throw "Visual Studio installation with MSBuild was not found."
+          }
+
+          $vstest = Join-Path $vsInstall 'Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe'
+          if (!(Test-Path $vstest)) {
+            throw "vstest.console.exe was not found at '$vstest'."
+          }
+
+          $testRoot = Join-Path 'Unit Tests\bin\${{ matrix.platform }}' $env:BUILD_CONFIGURATION
+          if (!(Test-Path $testRoot)) {
+            throw "Expected UWP test output directory was not found: '$testRoot'."
+          }
+
+          $testArtifact = Get-ChildItem -Path $testRoot -Recurse -Include '*.build.appxrecipe', '*.appx' |
+            Select-Object -First 1
+
+          if ($null -eq $testArtifact) {
+            Get-ChildItem -Path $testRoot -Recurse | Select-Object FullName
+            throw "No UWP test artifact was found under '$testRoot'."
+          }
+
+          New-Item -ItemType Directory -Force -Path TestResults | Out-Null
+
+          & $vstest $testArtifact.FullName `
+            /Framework:FrameworkUap10 `
+            /Logger:"trx;LogFileName=unit-tests-${{ matrix.platform }}.trx" `
+            /ResultsDirectory:TestResults
+
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+
+      - name: Upload build logs and test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: uwp-ci-${{ matrix.platform }}
+          if-no-files-found: ignore
+          path: |
+            artifacts/**
+            TestResults/**

--- a/.github/workflows/uwp-ci.yml
+++ b/.github/workflows/uwp-ci.yml
@@ -47,21 +47,18 @@ jobs:
 
       - name: Restore NuGet packages
         shell: pwsh
+        timeout-minutes: 10
         run: |
-          msbuild "${env:SOLUTION_PATH}" `
-            /t:Restore `
-            /p:Platform=${{ matrix.platform }} `
-            /p:Configuration=${env:BUILD_CONFIGURATION} `
-            /p:TargetPlatformVersion=${env:CI_TARGET_PLATFORM_VERSION}
+          nuget restore "${env:SOLUTION_PATH}" -NonInteractive -Verbosity normal
 
       - name: Build app and test project
         shell: pwsh
+        timeout-minutes: 25
         run: |
           New-Item -ItemType Directory -Force -Path artifacts | Out-Null
 
           msbuild "${env:SOLUTION_PATH}" `
             /m `
-            /restore `
             /p:Platform=${{ matrix.platform }} `
             /p:Configuration=${env:BUILD_CONFIGURATION} `
             /p:TargetPlatformVersion=${env:CI_TARGET_PLATFORM_VERSION} `
@@ -73,6 +70,7 @@ jobs:
 
       - name: Run UWP unit tests
         shell: pwsh
+        timeout-minutes: 10
         run: |
           $vswhere = 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe'
           $vsInstall = & $vswhere -latest -products '*' -requires Microsoft.Component.MSBuild -property installationPath

--- a/.github/workflows/uwp-ci.yml
+++ b/.github/workflows/uwp-ci.yml
@@ -48,8 +48,15 @@ jobs:
       - name: Show Visual Studio and SDK inventory
         shell: pwsh
         run: |
-          & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.Component.MSBuild -format table
-          Get-ChildItem 'C:\Program Files (x86)\Windows Kits\10\Platforms\UAP' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Name
+          $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+          if (Test-Path $vswhere) {
+            & $vswhere -latest -products '*' -requires Microsoft.Component.MSBuild -format table
+          }
+
+          $uapPlatformRoot = 'C:\Program Files (x86)\Windows Kits\10\Platforms\UAP'
+          if (Test-Path $uapPlatformRoot) {
+            Get-ChildItem $uapPlatformRoot | Select-Object -ExpandProperty Name
+          }
 
       - name: Restore NuGet packages
         shell: pwsh
@@ -80,8 +87,8 @@ jobs:
       - name: Run UWP unit tests
         shell: pwsh
         run: |
-          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-          $vsInstall = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationPath
+          $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+          $vsInstall = & $vswhere -latest -products '*' -requires Microsoft.Component.MSBuild -property installationPath
           if ([string]::IsNullOrWhiteSpace($vsInstall)) {
             throw "Visual Studio installation with MSBuild was not found."
           }

--- a/.github/workflows/uwp-ci.yml
+++ b/.github/workflows/uwp-ci.yml
@@ -45,19 +45,6 @@ jobs:
       - name: Add MSBuild to PATH
         uses: microsoft/setup-msbuild@v3
 
-      - name: Show Visual Studio and SDK inventory
-        shell: pwsh
-        run: |
-          $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
-          if (Test-Path $vswhere) {
-            & $vswhere -latest -products '*' -requires Microsoft.Component.MSBuild -format table
-          }
-
-          $uapPlatformRoot = 'C:\Program Files (x86)\Windows Kits\10\Platforms\UAP'
-          if (Test-Path $uapPlatformRoot) {
-            Get-ChildItem $uapPlatformRoot | Select-Object -ExpandProperty Name
-          }
-
       - name: Restore NuGet packages
         shell: pwsh
         run: |
@@ -87,7 +74,7 @@ jobs:
       - name: Run UWP unit tests
         shell: pwsh
         run: |
-          $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+          $vswhere = 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe'
           $vsInstall = & $vswhere -latest -products '*' -requires Microsoft.Component.MSBuild -property installationPath
           if ([string]::IsNullOrWhiteSpace($vsInstall)) {
             throw "Visual Studio installation with MSBuild was not found."

--- a/Authenticator/Views/Pages/AddPage.xaml.cs
+++ b/Authenticator/Views/Pages/AddPage.xaml.cs
@@ -1,10 +1,11 @@
-﻿using Domain.Storage;
+using Domain.Storage;
 using System;
 using System.Linq;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
 using Domain.Utilities;
+using Domain.Protocols;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.ApplicationModel.Resources;
 using Domain;
@@ -32,6 +33,7 @@ namespace Authenticator.Views.Pages
         private Account dragAndDropAccount;
         private static Account scannedAccount;
         private static bool didScan;
+        private byte accountDigits = TOTP.DEFAULT_DIGITS;
         private MobileBarcodeScanner scanner;
 
         public AddPage()
@@ -72,6 +74,7 @@ namespace Authenticator.Views.Pages
                     {
                         if (scannedAccount != null)
                         {
+                            accountDigits = scannedAccount.Digits;
                             AccountUsername.Text = scannedAccount.Username;
                             AccountCode.Text = scannedAccount.Secret;
                             AccountService.Text = scannedAccount.Service;
@@ -83,11 +86,13 @@ namespace Authenticator.Views.Pages
                         }
                         else
                         {
+                            accountDigits = TOTP.DEFAULT_DIGITS;
                             MainPage.AddBanner(new Banner(BannerType.Danger, ResourceLoader.GetForCurrentView().GetString("BannerInvalidCode"), true));
                         }
                     }
                     catch
                     {
+                        accountDigits = TOTP.DEFAULT_DIGITS;
                         MainPage.AddBanner(new Banner(BannerType.Danger, ResourceLoader.GetForCurrentView().GetString("BannerInvalidCode"), true));
                     }
                 }
@@ -243,9 +248,9 @@ namespace Authenticator.Views.Pages
 
                     if (valid)
                     {
-                        OTP otp = new OTP(code);
+                        OTP otp = new OTP(code, accountDigits);
 
-                        Account account = new Account(AccountUsername.Text, code, AccountService.Text);
+                        Account account = new Account(AccountUsername.Text, code, AccountService.Text, accountDigits);
 
                         await AccountStorage.Instance.SaveAsync(account);
 
@@ -260,6 +265,7 @@ namespace Authenticator.Views.Pages
                         AccountService.Text = "";
                         AccountUsername.Text = "";
                         AccountCode.Text = "";
+                        accountDigits = TOTP.DEFAULT_DIGITS;
                     }
                 }
                 catch (ArgumentException)
@@ -332,6 +338,7 @@ namespace Authenticator.Views.Pages
 
             if (dragAndDropAccount != null)
             {
+                accountDigits = dragAndDropAccount.Digits;
                 AccountUsername.Text = !string.IsNullOrWhiteSpace(dragAndDropAccount.Username) ? dragAndDropAccount.Username : "";
                 AccountCode.Text = !string.IsNullOrWhiteSpace(dragAndDropAccount.Secret) ? dragAndDropAccount.Secret : "";
                 AccountService.Text = !string.IsNullOrWhiteSpace(dragAndDropAccount.Service) ? dragAndDropAccount.Service : "";

--- a/Authenticator/Views/UserControls/AccountBlock.xaml
+++ b/Authenticator/Views/UserControls/AccountBlock.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Name="userControl"
+<UserControl x:Name="userControl"
     x:Class="Authenticator.Views.UserControls.AccountBlock"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -7,6 +7,11 @@
     xmlns:domain="using:Domain"
     mc:Ignorable="d"
     Height="110"
+    IsTabStop="True"
+    TabIndex="0"
+    KeyDown="Grid_KeyDown"
+    AutomationProperties.Name="{Binding Service}"
+    AutomationProperties.HelpText="Press Enter, Space, Ctrl+C, or Ctrl+Insert to copy the current code."
     d:DesignHeight="300"
     d:DesignWidth="400"
     DataContext="domain:Account">

--- a/Authenticator/Views/UserControls/AccountBlock.xaml.cs
+++ b/Authenticator/Views/UserControls/AccountBlock.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media.Animation;
@@ -10,6 +11,9 @@ using Domain.Utilities;
 using Domain.Storage;
 using Synchronization.Exceptions;
 using Authenticator.Views.Pages;
+using Windows.System;
+using Windows.UI.Core;
+using Windows.UI.Xaml.Input;
 
 namespace Authenticator.Views.UserControls
 {
@@ -98,7 +102,7 @@ namespace Authenticator.Views.UserControls
 
             this.account = account;
             this.mainPage = mainPage;
-            otp = new OTP(account.Secret);
+            otp = new OTP(account.Secret, account.Digits);
 
             DataContext = account;
 
@@ -117,10 +121,26 @@ namespace Authenticator.Views.UserControls
 
         private void DisplayCodeFormatted()
         {
-            string firstPart = otp.Code.Substring(0, 3);
-            string secondPart = otp.Code.Substring(3, 3);
+            CurrentCode.Text = FormatCode(otp.Code);
+        }
 
-            CurrentCode.Text = string.Format("{0} {1}", firstPart, secondPart);
+        private static string FormatCode(string code)
+        {
+            if (string.IsNullOrWhiteSpace(code) || code.Length <= 4)
+            {
+                return code;
+            }
+
+            int groupSize = code.Length % 3 == 0 ? 3 : 4;
+            List<string> groups = new List<string>();
+
+            for (int index = 0; index < code.Length; index += groupSize)
+            {
+                int remaining = code.Length - index;
+                groups.Add(code.Substring(index, Math.Min(groupSize, remaining)));
+            }
+
+            return string.Join(" ", groups);
         }
 
         public void Remove()
@@ -184,20 +204,44 @@ namespace Authenticator.Views.UserControls
             }
         }
 
-        private void Grid_Tapped(object sender, Windows.UI.Xaml.Input.TappedRoutedEventArgs e)
+        private void Grid_Tapped(object sender, TappedRoutedEventArgs e)
         {
             if (!InEditMode)
             {
-                if (Flash.GetCurrentState() != ClockState.Stopped)
-                {
-                    Flash.Stop();
-                }
-
-                Flash.Begin();
-
-                CopyCode();
-                NotifyCopyRequested();
+                CopyCodeAndNotify();
             }
+        }
+
+        private void Grid_KeyDown(object sender, KeyRoutedEventArgs e)
+        {
+            if (InEditMode)
+            {
+                return;
+            }
+
+            CoreVirtualKeyStates controlKeyState = Window.Current.CoreWindow.GetKeyState(VirtualKey.Control);
+            bool controlDown = (controlKeyState & CoreVirtualKeyStates.Down) == CoreVirtualKeyStates.Down;
+            bool copyShortcut = controlDown && (e.Key == VirtualKey.C || e.Key == VirtualKey.Insert);
+            bool activationKey = e.Key == VirtualKey.Enter || e.Key == VirtualKey.Space;
+
+            if (copyShortcut || activationKey)
+            {
+                CopyCodeAndNotify();
+                e.Handled = true;
+            }
+        }
+
+        private void CopyCodeAndNotify()
+        {
+            if (Flash.GetCurrentState() != ClockState.Stopped)
+            {
+                Flash.Stop();
+            }
+
+            Flash.Begin();
+
+            CopyCode();
+            NotifyCopyRequested();
         }
 
         private void CopyCode()
@@ -257,7 +301,7 @@ namespace Authenticator.Views.UserControls
             }
         }
 
-        private async void EditPanel_Tapped(object sender, Windows.UI.Xaml.Input.TappedRoutedEventArgs e)
+        private async void EditPanel_Tapped(object sender, TappedRoutedEventArgs e)
         {
             if (_editEnabled && InEditMode)
             {

--- a/Domain/Account.cs
+++ b/Domain/Account.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+using Domain.Protocols;
+using Newtonsoft.Json;
 using System.ComponentModel;
 
 namespace Domain
@@ -6,12 +7,26 @@ namespace Domain
     public class Account : INotifyPropertyChanged
     {
         private string _service;
+        private byte _digits = TOTP.DEFAULT_DIGITS;
         private bool isModified;
 
         public event PropertyChangedEventHandler PropertyChanged;
 
         public string Secret { get; set; }
         public string Username { get; set; }
+
+        public byte Digits
+        {
+            get
+            {
+                return _digits;
+            }
+            set
+            {
+                _digits = NormalizeDigits(value);
+            }
+        }
+
         public string Service
         {
             get
@@ -23,7 +38,7 @@ namespace Domain
                 _service = value;
                 isModified = true;
 
-                PropertyChanged(this, new PropertyChangedEventArgs("Service"));
+                NotifyPropertyChanged("Service");
             }
         }
 
@@ -36,11 +51,13 @@ namespace Domain
             }
         }
 
-        public Account(string username, string secret, string service)
+        [JsonConstructor]
+        public Account(string username, string secret, string service, byte digits = TOTP.DEFAULT_DIGITS)
         {
             Username = username;
             Secret = secret;
             _service = service;
+            Digits = digits;
         }
 
         public void Flush()
@@ -53,6 +70,34 @@ namespace Domain
             Account account = obj as Account;
 
             return account != null && account.Username == Username && account.Service == Service;
+        }
+
+        public override int GetHashCode()
+        {
+            int usernameHash = Username != null ? Username.GetHashCode() : 0;
+            int serviceHash = Service != null ? Service.GetHashCode() : 0;
+
+            return usernameHash ^ serviceHash;
+        }
+
+        private void NotifyPropertyChanged(string propertyName)
+        {
+            PropertyChangedEventHandler handler = PropertyChanged;
+
+            if (handler != null)
+            {
+                handler(this, new PropertyChangedEventArgs(propertyName));
+            }
+        }
+
+        private static byte NormalizeDigits(byte digits)
+        {
+            if (digits < TOTP.MIN_DIGITS || digits > TOTP.MAX_DIGITS)
+            {
+                return TOTP.DEFAULT_DIGITS;
+            }
+
+            return digits;
         }
     }
 }

--- a/Domain/OTP.cs
+++ b/Domain/OTP.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Windows.Security.Cryptography;
 using Windows.Security.Cryptography.Core;
 using Windows.Storage.Streams;
@@ -11,9 +11,12 @@ namespace Domain
     public class OTP
     {
         private CryptographicKey cKey;
+        private byte digits;
 
-        public OTP(string key)
+        public OTP(string key, byte digits = TOTP.DEFAULT_DIGITS)
         {
+            this.digits = NormalizeDigits(digits);
+
             MacAlgorithmProvider provider = MacAlgorithmProvider.OpenAlgorithm(MacAlgorithmNames.HmacSha1);
 
             IBuffer keyMaterial = CryptographicBuffer.CreateFromByteArray(key.ToBytesBase32());
@@ -26,8 +29,6 @@ namespace Domain
 
             IBuffer data = CryptographicBuffer.CreateFromByteArray(value);
             IBuffer buffer = CryptographicEngine.Sign(cKey, data);
-
-            string signature = CryptographicBuffer.EncodeToHexString(buffer);
 
             CryptographicBuffer.CopyToByteArray(buffer, out hash);
             return hash;
@@ -50,7 +51,7 @@ namespace Domain
 
         public bool IsValid(string totp)
         {
-            return totp.Equals(Generate());
+            return string.Equals(totp, Generate(), StringComparison.Ordinal);
         }
 
         private string Generate()
@@ -74,16 +75,25 @@ namespace Domain
 
             uint fullcode = BitConverter.ToUInt32(bytes, 0) & 0x7fffffff;
 
-            // we use the last x DIGITS of this code in radix 10
-            uint codemask = (uint)Math.Pow(10, TOTP.DIGITS);
+            // we use the last x digits of this code in radix 10
+            uint codemask = (uint)Math.Pow(10, digits);
 
             string totp = (fullcode % codemask).ToString();
 
-            // .NETmf has no required format string
-            while (totp.Length != TOTP.DIGITS)
+            while (totp.Length < digits)
                 totp = "0" + totp;
 
             return totp;
+        }
+
+        private static byte NormalizeDigits(byte digits)
+        {
+            if (digits < TOTP.MIN_DIGITS || digits > TOTP.MAX_DIGITS)
+            {
+                return TOTP.DEFAULT_DIGITS;
+            }
+
+            return digits;
         }
     }
 }

--- a/Domain/Protocols/TOTP.cs
+++ b/Domain/Protocols/TOTP.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -8,7 +8,10 @@ namespace Domain.Protocols
 {
     public class TOTP
     {
-        public const byte DIGITS = 6;
+        public const byte DEFAULT_DIGITS = 6;
+        public const byte DIGITS = DEFAULT_DIGITS;
+        public const byte MIN_DIGITS = 1;
+        public const byte MAX_DIGITS = 9;
         public const long EPOCH = 621355968000000000;
         public const int INTERVAL = 30000;
     }

--- a/Domain/Utilities/TOTPUtilities.cs
+++ b/Domain/Utilities/TOTPUtilities.cs
@@ -1,4 +1,4 @@
-﻿using Domain.Protocols;
+using Domain.Protocols;
 using System;
 
 namespace Domain.Utilities
@@ -6,8 +6,9 @@ namespace Domain.Utilities
     public class TOTPUtilities
     {
         private const string PREFIX = "otpauth://totp/";
-        private const string SECRET_SPLITTER = "?secret=";
-        private const string SERVICE_SPLITTER = ":";
+        private const string SECRET_KEY = "secret";
+        private const string ISSUER_KEY = "issuer";
+        private const string DIGITS_KEY = "digits";
 
         public static int RemainingSeconds
         {
@@ -47,6 +48,11 @@ namespace Domain.Utilities
 
         public static Account UriToAccount(string input)
         {
+            if (string.IsNullOrWhiteSpace(input))
+            {
+                return null;
+            }
+
             input = Uri.UnescapeDataString(input);
             Account account = null;
 
@@ -61,11 +67,12 @@ namespace Domain.Utilities
                     if (parts.Length == 2)
                     {
                         string name = parts[0];
-                        string secret = GetValue("secret", parts[1]);
-                        string service = GetValue("issuer", parts[1]);
+                        string secret = GetValue(SECRET_KEY, parts[1]);
+                        string service = GetValue(ISSUER_KEY, parts[1]);
+                        byte digits = GetByteValue(DIGITS_KEY, parts[1], TOTP.DEFAULT_DIGITS);
 
                         // Remove possibly prepended service (issuer) name
-                        if (name.StartsWith(service + ":"))
+                        if (!string.IsNullOrWhiteSpace(service) && name.StartsWith(service + ":"))
                         {
                             name = name.Substring(service.Length + 1);
                         }
@@ -81,7 +88,7 @@ namespace Domain.Utilities
                             }
                         }
 
-                        account = new Account(name, secret, service);
+                        account = new Account(name, secret, service, digits);
                     }
                 }
             }
@@ -102,7 +109,7 @@ namespace Domain.Utilities
 
                 if (part.Contains("="))
                 {
-                    string[] keyValue = part.Split('=');
+                    string[] keyValue = part.Split(new[] { '=' }, 2);
 
                     if (keyValue.Length == 2 && keyValue[0] == key)
                     {
@@ -111,6 +118,19 @@ namespace Domain.Utilities
                 }
 
                 index++;
+            }
+
+            return value;
+        }
+
+        private static byte GetByteValue(string key, string input, byte defaultValue)
+        {
+            string rawValue = GetValue(key, input);
+            byte value;
+
+            if (!byte.TryParse(rawValue, out value) || value < TOTP.MIN_DIGITS || value > TOTP.MAX_DIGITS)
+            {
+                return defaultValue;
             }
 
             return value;

--- a/Unit Tests/TOTPUtilitiesTest.cs
+++ b/Unit Tests/TOTPUtilitiesTest.cs
@@ -1,64 +1,85 @@
-﻿using System;
 using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
 using Domain;
+using Domain.Protocols;
 using Domain.Utilities;
 
 namespace Unit_Tests
 {
     [TestClass]
-    public class UnitTest1
+    public class TOTPUtilitiesTest
     {
+        private const string ExampleSecret = "EXAMPLE";
+
         [TestMethod]
         public void TestMicrosoft()
         {
-            string input = "otpauth://totp/Microsoft:user@hotmail.com?secret=2FA662OCY6FLRKY5&issuer=Microsoft";
+            string input = "otpauth://totp/Microsoft:user@hotmail.com?secret=" + ExampleSecret + "&issuer=Microsoft";
             Account account = TOTPUtilities.UriToAccount(input);
 
-            Validate("user@hotmail.com", "2FA662OCY6FLRKY5", "Microsoft", account);
+            Validate("user@hotmail.com", ExampleSecret, "Microsoft", account);
         }
 
         [TestMethod]
         public void TestGoogle()
         {
-            string input = "otpauth://totp/Google%3Auser%40gmail.com?secret=uhs6vc47fttwgglvsyevlbjoczoyyeem&issuer=Google";
+            string input = "otpauth://totp/Google%3Auser%40gmail.com?secret=" + ExampleSecret + "&issuer=Google";
             Account account = TOTPUtilities.UriToAccount(input);
 
-            Validate("user@gmail.com", "uhs6vc47fttwgglvsyevlbjoczoyyeem", "Google", account);
+            Validate("user@gmail.com", ExampleSecret, "Google", account);
         }
 
         [TestMethod]
         public void TestDropbox()
         {
-            string input = "otpauth://totp/Dropbox:user@hotmail.com?secret=EK6VFBVGIGJ4FX6KYONLBQSJH4&issuer=Dropbox";
+            string input = "otpauth://totp/Dropbox:user@hotmail.com?secret=" + ExampleSecret + "&issuer=Dropbox";
             Account account = TOTPUtilities.UriToAccount(input);
 
-            Validate("user@hotmail.com", "EK6VFBVGIGJ4FX6KYONLBQSJH4", "Dropbox", account);
+            Validate("user@hotmail.com", ExampleSecret, "Dropbox", account);
         }
 
         [TestMethod]
         public void TestDiskStation()
         {
-            string input = "otpauth://totp/Administrator@DiskStation?secret=A7LAL5KRDBZWRRHT";
+            string input = "otpauth://totp/Administrator@DiskStation?secret=" + ExampleSecret;
             Account account = TOTPUtilities.UriToAccount(input);
 
-            Validate("Administrator", "A7LAL5KRDBZWRRHT", "DiskStation", account);
+            Validate("Administrator", ExampleSecret, "DiskStation", account);
         }
 
         [TestMethod]
         public void TestVersio()
         {
-            string input = "otpauth://totp/12345?secret=R6H7USVWDYQLNQWD&issuer=Versio";
+            string input = "otpauth://totp/12345?secret=" + ExampleSecret + "&issuer=Versio";
             Account account = TOTPUtilities.UriToAccount(input);
 
-            Validate("12345", "R6H7USVWDYQLNQWD", "Versio", account);
+            Validate("12345", ExampleSecret, "Versio", account);
         }
 
-        private void Validate(string username, string secret, string service, Account account)
+        [TestMethod]
+        public void TestDigitsParameter()
+        {
+            string input = "otpauth://totp/Blizzard:user@example.com?secret=" + ExampleSecret + "&issuer=Blizzard&digits=8";
+            Account account = TOTPUtilities.UriToAccount(input);
+
+            Validate("user@example.com", ExampleSecret, "Blizzard", account, 8);
+        }
+
+        [TestMethod]
+        public void TestInvalidDigitsParameterDefaultsToSixDigits()
+        {
+            string input = "otpauth://totp/Example:user@example.com?secret=" + ExampleSecret + "&issuer=Example&digits=99";
+            Account account = TOTPUtilities.UriToAccount(input);
+
+            Validate("user@example.com", ExampleSecret, "Example", account);
+        }
+
+        private void Validate(string username, string secret, string service, Account account, byte digits = TOTP.DEFAULT_DIGITS)
         {
             Assert.IsNotNull(account);
             Assert.AreEqual(username, account.Username);
             Assert.AreEqual(secret, account.Secret);
             Assert.AreEqual(service, account.Service);
+            Assert.AreEqual(digits, account.Digits);
         }
     }
 }

--- a/docs/maintenance-review-2026-06.md
+++ b/docs/maintenance-review-2026-06.md
@@ -1,0 +1,83 @@
+# WinOTP Authenticator maintenance review - June 2026
+
+This review is based on the open GitHub issues in `VladimirAkopyan/Authenticator`, the current UWP codebase, and the Microsoft Store association metadata in `Authenticator/Package.StoreAssociation.xml`.
+
+## Feedback themes from open issues
+
+| Theme | Representative issues | Notes |
+| --- | --- | --- |
+| Backup, export, restore, and migration | #8, #22, #24 | Users want to move accounts to a new PC and recover from device loss without relying on OneDrive sync. |
+| Cloud sync reliability | #1, #3, #6, #24 | The OneDrive SDK dependency is old and user reports indicate setup/sync failures. |
+| OTP compatibility | #5, #9 | Users reported valid use cases for non-6-digit TOTP codes and time-related code mismatches. |
+| Keyboard and automation accessibility | #12 | Users expect Enter, Space, Ctrl+C, and Ctrl+Insert to copy the focused code. |
+| List management | #14, #16, #17 | Users ask for rename, search, and persistent alphabetical sorting. |
+| UI density and layout | #7, #10, #11 | Users report oversized list items, layout direction issues, and unclear add-account affordances. |
+| Packaging | #13, #15, #21 | Users ask for sideloading/installers; Windows 7 is out of scope for UWP, but `.appinstaller` packaging is feasible. |
+| Maintenance status | #20 | Users are asking whether the app is still maintained. A public roadmap/release note would help. |
+
+## Changes included in this PR
+
+This PR intentionally keeps the first change set small and low-risk:
+
+1. Adds a persisted `Digits` value to `Domain.Account` with backwards-compatible defaulting to 6 digits.
+2. Updates `Domain.OTP` to generate 1-9 digit codes, defaulting to 6.
+3. Parses the `digits` parameter from `otpauth://totp/...` URIs.
+4. Preserves scanned and drag-and-drop QR code digit counts when adding accounts.
+5. Displays variable-length codes without assuming exactly six digits.
+6. Makes account blocks keyboard-focusable and supports Enter, Space, Ctrl+C, and Ctrl+Insert for copy.
+7. Adds URI parsing tests for valid and invalid `digits` parameters.
+
+This directly starts addressing #5 and #12, and lays groundwork for import/export because account metadata now carries digit count explicitly.
+
+## Codebase observations
+
+### UWP and dependency age
+
+The solution is still a UWP app targeting Windows 10 SDK `10.0.18362.0` with a minimum target of `10.0.17763.0`. Several dependencies are old, including `Microsoft.OneDriveSDK` 1.2.0, `Microsoft.UI.Xaml` 2.1, and `Newtonsoft.Json` 12.0.2.
+
+### Storage and security
+
+Local account storage uses `Windows.Security.Cryptography.DataProtection.DataProtectionProvider` with the `LOCAL=user` descriptor, which is appropriate for user-scoped local protection. Export/import should therefore be explicit, encrypted, and warning-heavy because exported OTP seeds become portable secrets.
+
+The separate `Encryption.AESEncrypter` implementation uses AES-CBC with a derived IV and no authentication tag. Do not extend that format for new backup/export features. Prefer a versioned export format with authenticated encryption and a strong KDF.
+
+### Reliability
+
+`AccountStorage` contains several broad `catch` blocks, `async void` cleanup, and `throw e;` rethrows. These should be corrected in a reliability-focused PR before major storage or sync changes.
+
+### UX and accessibility
+
+The current account item layout is visually simple but assumes pointer interaction and six-digit codes. This PR adds keyboard copy. Follow-up UX work should add search, sort, density settings, clearer empty-state/add affordances, RTL validation, and accessible labels across the app.
+
+## Modernization backlog
+
+Suggested sequencing:
+
+1. **Patch compatibility and accessibility**
+   - Finish manual UI support for digit count.
+   - Add keyboard and screen-reader coverage for add/edit flows.
+   - Add code generation tests with RFC-compatible vectors.
+
+2. **Backup/export/import**
+   - Add encrypted export with clear warnings.
+   - Add import preview and duplicate handling.
+   - Consider QR and JSON export variants, but never expose seeds without explicit confirmation.
+
+3. **Sync replacement**
+   - Reassess the OneDrive SDK integration.
+   - Add structured sync errors and telemetry/logging hooks.
+   - Decouple sync from local persistence where possible.
+
+4. **List management**
+   - Rename service/account labels.
+   - Search entries.
+   - Persist custom vs alphabetical sorting.
+
+5. **Packaging and release operations**
+   - Add CI build validation.
+   - Add release notes.
+   - Consider `.appinstaller` distribution for users who do not want Store installation.
+
+6. **Platform modernization**
+   - Keep this UWP app stable for existing Store users.
+   - Evaluate a separate Windows App SDK / WinUI 3 port branch. This is likely a larger rewrite, not a safe single PR.


### PR DESCRIPTION
## Summary

This PR starts addressing the most actionable user feedback from the open issue backlog while keeping the change set small enough to review safely.

### User feedback addressed

- #5: support non-6-digit TOTP codes, especially 8-digit Blizzard-style TOTP entries.
- #12: allow keyboard-driven copying for automation and accessibility.

### Code changes

- Adds a persisted `Digits` property to `Domain.Account`, defaulting old accounts to 6 digits.
- Updates `Domain.OTP` to generate 1-9 digit TOTP values instead of assuming `TOTP.DIGITS == 6` everywhere.
- Parses `digits` from `otpauth://totp/...` URIs.
- Preserves digit count from scanned QR codes and drag-and-drop QR imports.
- Displays variable-length OTP codes without fixed `Substring(0, 3)` / `Substring(3, 3)` assumptions.
- Makes account blocks keyboard-focusable and supports Enter, Space, Ctrl+C, and Ctrl+Insert for copy.
- Adds tests for `digits` URI parsing and invalid digit fallback.

### CI workflow

Adds `.github/workflows/uwp-ci.yml`.

The workflow:

- runs on `windows-2022`;
- uses `microsoft/setup-msbuild@v3`;
- builds `Authenticator for Windows.sln` for x86 and x64;
- overrides the CI Windows SDK to `10.0.19041.0`, because the project targets `10.0.18362.0` but the hosted runner does not currently include that SDK;
- disables app package signing during CI;
- runs the UWP test artifact with `vstest.console.exe`;
- uploads MSBuild binary logs and `.trx` test results.

### Maintenance review

Added `docs/maintenance-review-2026-06.md` with a review of open user feedback and a proposed modernization sequence:

1. Compatibility/accessibility fixes.
2. Backup/export/import.
3. Sync replacement.
4. Search/sort/list management.
5. Packaging and release operations.
6. Windows App SDK / WinUI 3 evaluation as a separate porting effort.

## Validation

- GitHub Actions `UWP CI` run #8 completed successfully on the latest PR head.
- x86 job succeeded: restore, build, UWP unit tests, artifact upload.
- x64 job succeeded: restore, build, UWP unit tests, artifact upload.

## Notes

This intentionally does not attempt a full Windows App SDK migration. That should be a separate project/branch because the current app is a Store-published UWP app with existing local storage and sync behaviour.